### PR TITLE
fix build failure due to kvm-bindng serde branch not found

### DIFF
--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["The Chromium OS Authors"]
 [dependencies]
 byteorder = "=1.2.1"
 libc = ">=0.2.39"
-kvm-bindings = { git = "https://github.com/princeton-sns/kvm-bindings", branch = "serde" }
+kvm-bindings = { git = "https://github.com/princeton-sns/kvm-bindings", branch = "master" }
 
 arch_gen = { path = "../arch_gen" }
 kvm = { path = "../kvm" }

--- a/cpuid/Cargo.toml
+++ b/cpuid/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
-kvm-bindings = { git = "https://github.com/princeton-sns/kvm-bindings", branch = "serde" }
+kvm-bindings = { git = "https://github.com/princeton-sns/kvm-bindings", branch = "master" }
 kvm = { path = "../kvm" }

--- a/kvm/Cargo.toml
+++ b/kvm/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Chromium OS Authors"]
 
 [dependencies]
 libc = ">=0.2.39"
-kvm-bindings = { git = "https://github.com/princeton-sns/kvm-bindings", branch = "serde" }
+kvm-bindings = { git = "https://github.com/princeton-sns/kvm-bindings", branch = "master" }
 
 sys_util = { path = "../sys_util" }
 

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = ">=1.0.9"
 time = ">=0.1.39"
 timerfd = ">=1.0"
 byteorder = ">=1.2.1"
-kvm-bindings = { git = "https://github.com/princeton-sns/kvm-bindings", branch = "serde" }
+kvm-bindings = { git = "https://github.com/princeton-sns/kvm-bindings", branch = "master" }
 
 arch = { path = "../arch" }
 devices = { path = "../devices" }


### PR DESCRIPTION
After the snapshot PR merge, build still breaks on my end due to the `serde` branch not found in the `princeton-sns/kvm-binding` repo. I fixed the build failure by changing all the `.toml` files that has `kvm-bindings = { git = "https://github.com/princeton-sns/kvm-bindings", branch = "serde" }`. Please advise if this is the right fix.

```
[luzhuo@Jasper] grep -rl "sns" *.toml .
./kvm/Cargo.toml
./arch/Cargo.toml
./vmm/Cargo.toml
./cpuid/Cargo.toml
```
