### PR TITLE
Allocate private (not shared) memory for guest

### DIFF
--- a/memory_model/src/mmap.rs
+++ b/memory_model/src/mmap.rs
@@ -60,7 +60,7 @@ impl MemoryMapping {
                 null_mut(),
                 size,
                 libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_ANONYMOUS | libc::MAP_SHARED | libc::MAP_NORESERVE,
+                libc::MAP_ANONYMOUS | libc::MAP_PRIVATE | libc::MAP_NORESERVE,
                 -1,
                 0,
             )


### PR DESCRIPTION
Memory allocated for the guest VM doesn't actually need to be `MAP_SHARED` it appears---it's shared
between the VMM and the VM thread, but not between processes.

Mapping it as `MAP_PRIVATE` private reduces cleanup time by about 10ms for larger VMs (~4GB) on my desktop. Seems worth it, though not tested rigorously, just with a handful of invocations of different functions that seem to run correctly.