### PR TITLE
Advance rip register when taking a snapshot

### DIFF
--- a/vmm/src/vstate.rs
+++ b/vmm/src/vstate.rs
@@ -567,6 +567,7 @@ impl Vcpu {
                         if let Some(ref sender) = snap_sender {
                             let mut vcpu_state = VcpuState::default();
                             self.dump_vcpu_state(&mut vcpu_state)?;
+                            vcpu_state.regs.rip += 1;
                             sender.send(VcpuInfo{
                                 id: self.id,
                                 state: vcpu_state,


### PR DESCRIPTION
When taking a snapshot, the rip register is pointing to the instruction
that executed `outl`. If we restore to that point we will execute the
instruction again.

In the specific case of trying to take a SnapFaaS diff spanshot, the
result is _actually_ taking a nearly empty diff snapshot without
initializing the app whatsoever! Why? Because we load into the runtime
snapshot which, because the RIP register is pointing to the `outl`
instruction **immiediately takes the diff snapshot without doing
anything else!**.

The fix is to manually increment the RIP register (as the CPU would
do under regular execution) before serializing the captures registers to
the snapshot. Anecdotally, this pretty uniformly makes boot time for
_all_ applications around 5ms, several orders of magnitude decrease from
some of the heavier weight applications that require significant
initialization.

/cc @tan-yue: Please urgently review and redo _all_ benchmarks if you agree. I've tested with a few apps and at least two runtimes and am fairly certain this is correct.