### PR TITLE
print out boot time upon receiving signal 123

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2422,6 +2422,9 @@ impl Vmm {
 
         let boot_time_us = now_us - t0_ts.time_us;
         let boot_time_cpu_us = now_cpu_us - t0_ts.cputime_us;
+	
+        println!("child_process: Vm boot time: {} us", boot_time_us);
+        
         fc_util::fc_log!(
             "firecracker: Guest-boot-time: {:>6} us, {:>6} CPU us",
             boot_time_us,


### PR DESCRIPTION
Issue #, if available:

Description of changes: corresponds to PR #12 in snapfaas-image, for recoding the boot time before vsock connection.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
